### PR TITLE
Use security copyright file URI.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+4pane (5.0-2) UNRELEASED; urgency=medium
+
+  * Use security copyright file URI.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Sun, 16 Sep 2018 00:34:33 +0100
+
 4pane (5.0-1) testing; urgency=medium
 
   * New upstream version.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: 4Pane
 Upstream-Contact: David Hart <david@4Pane.co.uk>
 Source: http://sourceforge.net/projects/fourpane/files/


### PR DESCRIPTION
Use security copyright file URI.

Fixes lintian: insecure-copyright-format-uri
See https://lintian.debian.org/tags/insecure-copyright-format-uri.html for more details.
